### PR TITLE
Add root docker-compose config and update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 ## Run all services using docker compose for development
 dev:
-	docker compose -f infra/compose/docker-compose.yml up --build
+	docker compose up --build
 
 ## Run a demo wide research task via CLI (requires API service running)
 demo-wide-research:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OpenManus‑Stack is an open‑source, self‑hostable alternative to [Manus.im]
 
 ## Quick Start
 
-Ensure you have Docker and Docker Compose installed.  Clone this repository and run the stack:
+Ensure you have Docker and Docker Compose installed.  Clone this repository and run the stack using the provided `docker-compose.yml`:
 
 ```bash
 git clone https://github.com/your-user/openmanus-stack.git

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:18-alpine
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+# Only copy the package manifest(s) – a lockfile isn't required
+# and the build should not fail if one isn't present.
+COPY package*.json ./
 RUN npm install
 
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   # API service
   api:
     build:
-      context: ../../services/api
+      context: services/api
       dockerfile: Dockerfile
     depends_on:
       - db
@@ -76,7 +76,7 @@ services:
 
   orchestrator:
     build:
-      context: ../../services/orchestrator
+      context: services/orchestrator
       dockerfile: Dockerfile
     depends_on:
       - api
@@ -97,7 +97,7 @@ services:
 
   worker:
     build:
-      context: ../../services/worker
+      context: services/worker
       dockerfile: Dockerfile
     depends_on:
       - cache
@@ -113,7 +113,7 @@ services:
 
   frontend:
     build:
-      context: ../../apps/frontend
+      context: apps/frontend
       dockerfile: Dockerfile
     environment:
       - NEXT_PUBLIC_API_URL=http://api:8000
@@ -128,14 +128,14 @@ services:
     command:
       - "--config=/etc/otelcol/config.yaml"
     volumes:
-      - ./otel-collector-config.yaml:/etc/otelcol/config.yaml
+      - ./infra/compose/otel-collector-config.yaml:/etc/otelcol/config.yaml
     ports:
       - "4317:4317"
 
   prometheus:
     image: prom/prometheus
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./infra/compose/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
 
@@ -153,3 +153,4 @@ volumes:
   db_data:
   minio_data:
   meili_data:
+

--- a/docs/docs/developer-guide.md
+++ b/docs/docs/developer-guide.md
@@ -12,7 +12,7 @@ The repository uses a PNPM workspace layout:
 * `services/worker` — RQ worker for long‑running tasks.
 * `packages/tools` — Modular tool adapters.
 * `packages/model-router` — Model routing logic.
-* `infra/compose` — Docker Compose and other deployment artifacts.
+* `infra` — Supporting infrastructure configuration (OpenTelemetry, Prometheus, etc.). The Docker Compose file lives at the repository root.
 * `docs` — MkDocs documentation.
 * `tests` — Pytest/Jest test suites and GAIA evaluation harness.
 


### PR DESCRIPTION
## Summary
- move docker-compose.yml to repository root so `docker compose up` works as documented
- update Quick Start, developer guide, and Makefile to use the root compose file
- relax frontend Dockerfile to copy package manifests without requiring a lockfile

## Testing
- `make lint`
- `PYTHONPATH=. pytest -q` *(fails: AsyncClient.__init__() got an unexpected keyword argument 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6895b06a2a5c83288b154cdf0fcedf27